### PR TITLE
Pratt traversing for handling operator precedence and associativity

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, PartialEq, Debug)]
+use crate::ast::Expression::Application;
+
+#[derive(PartialEq, Debug, Clone)]
 pub enum Expression {
     IntegerLiteral(i64),
     StringLiteral(String),
@@ -24,6 +26,26 @@ impl Expression {
             },
         )
     }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct OperatorMetadata {
+    pub position: AffixPosition,
+    pub associativity: Associativity,
+    pub precedence: i8,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum AffixPosition {
+    Pre,
+    In,
+    Post,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Associativity {
+    Left,
+    Right,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -26,6 +26,14 @@ impl Expression {
             },
         )
     }
+
+    pub fn prefix_operation(operator: Expression, arg: Expression) -> Expression {
+        Application(Box::new(operator), ArgList { args: vec![arg] })
+    }
+
+    pub fn postfix_operation(operator: Expression, arg: Expression) -> Expression {
+        Application(Box::new(operator), ArgList { args: vec![arg] })
+    }
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,13 +5,28 @@ pub enum Expression {
     BooleanLiteral(bool),
     Named(String),
     Let(String, Box<Expression>, Box<Expression>),
-    Lambda(Option<String>, ParamList, Box<Expression>, Box<Expression>),
-    // TODO: Drop separate InfixOperation node and unify it under Application
-    InfixOperation(String, Box<Expression>, Box<Expression>),
+    Lambda(
+        Option<String>,
+        ParamList,
+        Box<Expression>,
+        Box<Expression>,
+        Option<OperatorMetadata>,
+    ),
     Application(Box<Expression>, ArgList),
 }
 
-#[derive(Clone, PartialEq, Debug)]
+impl Expression {
+    pub fn infix_operation(operator: Expression, lhs: Expression, rhs: Expression) -> Expression {
+        Application(
+            Box::new(operator),
+            ArgList {
+                args: vec![lhs, rhs],
+            },
+        )
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
 pub struct Param {
     pub name: String,
     pub type_expr: Expression,

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -50,5 +50,6 @@ infix_operation = { infix_op | invocation }
 
 primary_expr = _{ let_expr | lambda_expr | (term | invocation) }
 
-expr = { primary_expr ~ expr_tail? }
+parenthesized_expr = { LPAREN ~ expr ~ RPAREN }
+expr = { (parenthesized_expr | primary_expr) ~ expr_tail?}
 expr_tail = { infix_operation ~ expr }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -45,9 +45,10 @@ arg_list = { arg ~ (COMMA_SEP ~ arg)* }
 call = { LPAREN ~ arg_list ~ RPAREN | LPAREN ~ RPAREN }
 invocation = { named ~ call? }
 
-infix_operation = { "+" | "-" | "*" | "/" | "==" | "!=" | "<" | "<=" | ">" | ">=" | identifier }
+infix_op = { "+" | "-" | "*" | "/" | "^" | "==" | "!=" | "<" | "<=" | ">" | ">=" }
+infix_operation = { infix_op | invocation }
 
-complex_expr = _{ let_expr | lambda_expr }
+primary_expr = _{ let_expr | lambda_expr | (term | invocation) }
 
-expr = { complex_expr ~ expr_tail? | (term | invocation) ~ expr_tail? }
+expr = { primary_expr ~ expr_tail? }
 expr_tail = { infix_operation ~ expr }

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -96,6 +96,9 @@ impl<'a> PestParser<'a> {
 
     fn build_primary_expr(&self, pair: Pair<Rule>) -> Expression {
         match pair.as_rule() {
+            Rule::parenthesized_expr => {
+                PestParser::build_ast_from_expr(self, pair.into_inner().next().unwrap())
+            }
             Rule::integer => Expression::IntegerLiteral(pair.as_str().parse::<i64>().unwrap()),
             Rule::string => {
                 Expression::StringLiteral(pair.into_inner().next().unwrap().as_str().to_string())
@@ -544,6 +547,32 @@ mod tests {
                 Expression::Named("+".to_string()),
                 Expression::Named("a".to_string()),
                 Expression::Named("b".to_string())
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("(a + b) * c"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("*".to_string()),
+                Expression::infix_operation(
+                    Expression::Named("+".to_string()),
+                    Expression::Named("a".to_string()),
+                    Expression::Named("b".to_string())
+                ),
+                Expression::Named("c".to_string()),
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("a * (b + c)"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("*".to_string()),
+                Expression::Named("a".to_string()),
+                Expression::infix_operation(
+                    Expression::Named("+".to_string()),
+                    Expression::Named("b".to_string()),
+                    Expression::Named("c".to_string())
+                ),
             )])
         );
 

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -42,7 +42,7 @@ impl<'a> PestParser<'a> {
             None => (lhs_expr, pairs),
             Some(pair) => {
                 let operator_metadata =
-                    PestParser::get_prec_metadata(self, pair.into_inner().peek().unwrap());
+                    PestParser::get_op_metadata(self, pair.into_inner().peek().unwrap());
 
                 let next_binding_power = operator_metadata.precedence;
 
@@ -74,7 +74,7 @@ impl<'a> PestParser<'a> {
     }
 
     #[inline]
-    fn get_prec_metadata(&self, pair: Pair<Rule>) -> OperatorMetadata {
+    fn get_op_metadata(&self, pair: Pair<Rule>) -> OperatorMetadata {
         let default_operator_metadata = OperatorMetadata {
             position: AffixPosition::In,
             associativity: Associativity::Left,

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -523,14 +523,33 @@ mod tests {
 
     #[test]
     fn test_infix_expression() {
-        let parser = PestParser::new_with_operator_metadata(HashMap::from_iter([(
-            "^",
-            OperatorMetadata {
-                position: AffixPosition::In,
-                associativity: Associativity::Right,
-                precedence: 30,
-            },
-        )]));
+        let parser =
+            PestParser::new_with_operator_metadata(HashMap::from_iter([
+                (
+                    "/",
+                    OperatorMetadata {
+                        position: AffixPosition::In,
+                        associativity: Associativity::Right,
+                        precedence: 30,
+                    },
+                ),
+                (
+                    "*",
+                    OperatorMetadata {
+                        position: AffixPosition::In,
+                        associativity: Associativity::Right,
+                        precedence: 35,
+                    },
+                ),
+                (
+                    "^",
+                    OperatorMetadata {
+                        position: AffixPosition::In,
+                        associativity: Associativity::Right,
+                        precedence: 40,
+                    },
+                ),
+            ]));
 
         assert_eq!(
             parser.parse_expr("a+b"),
@@ -612,6 +631,23 @@ mod tests {
                     Expression::Named("b".to_string())
                 ),
                 Expression::Named("c".to_string())
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("a * b / c + d"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("+".to_string()),
+                Expression::infix_operation(
+                    Expression::Named("/".to_string()),
+                    Expression::infix_operation(
+                        Expression::Named("*".to_string()),
+                        Expression::Named("a".to_string()),
+                        Expression::Named("b".to_string())
+                    ),
+                    Expression::Named("c".to_string())
+                ),
+                Expression::Named("d".to_string())
             )])
         );
 

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -1,47 +1,127 @@
-use crate::ast::{ArgList, Expression, Param, ParamList};
+use crate::ast::{
+    AffixPosition, ArgList, Associativity, Expression, OperatorMetadata, Param, ParamList,
+};
 use pest::error::Error;
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
 use pest_derive::Parser;
+use std::collections::HashMap;
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
-pub struct PestParser;
+pub struct PestParser<'a> {
+    operator_metadata_mapping: HashMap<&'a str, OperatorMetadata>,
+}
 
-impl PestParser {
-    fn build_ast_from_expr(pair: Pair<Rule>) -> Expression {
-        let mut pairs = pair.into_inner();
-        let lhs = pairs.next().unwrap();
-        let remainder_opt = pairs.next();
+impl<'a> PestParser<'a> {
+    fn build_ast_from_expr(&self, pair: Pair<Rule>) -> Expression {
+        PestParser::pratt(self, Pairs::single(pair), 0).0
+    }
 
-        let lhs_expr = match lhs.as_rule() {
-            Rule::integer => Expression::IntegerLiteral(lhs.as_str().parse::<i64>().unwrap()),
-            Rule::string => {
-                Expression::StringLiteral(lhs.into_inner().next().unwrap().as_str().to_string())
+    #[inline]
+    fn pratt(
+        &self,
+        mut pairs: Pairs<'a, Rule>,
+        binding_power_limit: i8,
+    ) -> (Expression, Pairs<Rule>) {
+        let mut inner = pairs.next().unwrap().into_inner();
+        let lhs_pair = inner.next().unwrap();
+        let lhs_expr = PestParser::build_primary_expr(self, lhs_pair);
+
+        PestParser::pratt_loop(self, binding_power_limit, lhs_expr, inner)
+    }
+
+    #[inline]
+    fn pratt_loop(
+        &'a self,
+        binding_power_limit: i8,
+        lhs_expr: Expression,
+        mut pairs: Pairs<'a, Rule>,
+    ) -> (Expression, Pairs<'a, Rule>) {
+        match pairs.peek() {
+            None => (lhs_expr, pairs),
+            Some(pair) => {
+                let operator_metadata =
+                    PestParser::get_prec_metadata(self, pair.into_inner().peek().unwrap());
+
+                let next_binding_power = operator_metadata.precedence;
+
+                if next_binding_power > binding_power_limit {
+                    let mut inner = pairs.next().unwrap().into_inner();
+
+                    let operator = PestParser::extract_operator(
+                        self,
+                        inner.next().expect("Operator pair should be Some"),
+                    );
+
+                    let right_binding_power = if operator_metadata.associativity
+                        == Associativity::Right
+                    {
+                        next_binding_power - 1
+                    } else {
+                        next_binding_power
+                    };
+
+                    let (rhs_expr, remainder) = PestParser::pratt(self, inner, right_binding_power);
+                    let new_lhs_expr = Expression::infix_operation(operator, lhs_expr, rhs_expr);
+
+                    PestParser::pratt_loop(self, binding_power_limit, new_lhs_expr, remainder)
+                } else {
+                    (lhs_expr, pairs)
+                }
             }
-            Rule::boolean => Expression::BooleanLiteral(lhs.as_str().parse::<bool>().unwrap()),
-            Rule::expr => PestParser::build_ast_from_expr(lhs.into_inner().next().unwrap()),
+        }
+    }
+
+    #[inline]
+    fn get_prec_metadata(&self, pair: Pair<Rule>) -> OperatorMetadata {
+        let default_operator_metadata = OperatorMetadata {
+            position: AffixPosition::In,
+            associativity: Associativity::Left,
+            precedence: 20,
+        };
+
+        match pair.as_rule() {
+            Rule::infix_operation => {
+                let pairs = &mut pair.into_inner();
+                let operator = pairs.next().unwrap().as_str();
+                self.operator_metadata_mapping
+                    .get(operator)
+                    .unwrap_or(&default_operator_metadata)
+                    .clone()
+            }
+            _ => default_operator_metadata.clone(),
+        }
+    }
+
+    fn build_primary_expr(&self, pair: Pair<Rule>) -> Expression {
+        match pair.as_rule() {
+            Rule::integer => Expression::IntegerLiteral(pair.as_str().parse::<i64>().unwrap()),
+            Rule::string => {
+                Expression::StringLiteral(pair.into_inner().next().unwrap().as_str().to_string())
+            }
+            Rule::boolean => Expression::BooleanLiteral(pair.as_str().parse::<bool>().unwrap()),
             Rule::let_expr => {
-                let mut pairs = lhs.into_inner();
+                let pairs = &mut pair.into_inner();
 
                 let identifier = pairs.next().unwrap();
                 let type_expr = pairs.next().unwrap();
                 let expr = pairs.next().unwrap();
 
-                PestParser::build_let_expr(identifier, type_expr, expr)
+                PestParser::build_let_expr(self, identifier, type_expr, expr)
             }
             Rule::lambda_expr => {
-                let mut pairs = lhs.into_inner();
+                let pairs = &mut pair.into_inner();
 
                 let lambda_name = pairs.next().unwrap();
                 let param_list = pairs.next().unwrap();
                 let type_expr = pairs.next().unwrap();
                 let body_expr = pairs.next().unwrap();
 
-                PestParser::build_lambda_expr(lambda_name, param_list, type_expr, body_expr)
+                PestParser::build_lambda_expr(self, lambda_name, param_list, type_expr, body_expr)
             }
             Rule::invocation => {
-                let mut pairs = lhs.into_inner();
+                let pairs = &mut pair.into_inner();
 
                 let named = pairs.next().unwrap();
 
@@ -50,35 +130,31 @@ impl PestParser {
                 match call_opt {
                     None => Expression::Named(named.as_str().to_string()),
                     Some(call_with_args) => {
-                        PestParser::build_application_expr(named, call_with_args)
+                        PestParser::build_application_expr(self, named, call_with_args)
                     }
                 }
             }
             unknown_term => panic!("Unexpected term: {:?}", unknown_term),
-        };
-
-        match remainder_opt {
-            None => lhs_expr,
-            Some(remainder) => {
-                let mut pairs = remainder.into_inner();
-
-                let operator = pairs.next().unwrap().as_str().to_string();
-                let rhs_expr = PestParser::build_ast_from_expr(pairs.next().unwrap());
-
-                PestParser::combine_infix_operation_expr(lhs_expr, operator, rhs_expr)
-            }
         }
     }
 
-    fn combine_infix_operation_expr(
-        lhs: Expression,
-        operator: String,
-        rhs: Expression,
-    ) -> Expression {
-        Expression::InfixOperation(operator, Box::new(lhs), Box::new(rhs))
+    fn extract_operator(&self, pair: Pair<Rule>) -> Expression {
+        match pair.as_rule() {
+            Rule::infix_operation => {
+                let pairs = &mut pair.into_inner();
+                let operator_pair = pairs.next().unwrap();
+                match operator_pair.as_rule() {
+                    Rule::infix_op => Expression::Named(operator_pair.as_str().to_string()),
+                    Rule::invocation => PestParser::build_primary_expr(self, operator_pair),
+                    unknown_term => panic!("Unexpected term: {:?}", unknown_term),
+                }
+            }
+            unknown_term => panic!("Unexpected term: {:?}", unknown_term),
+        }
     }
 
     fn build_let_expr(
+        &self,
         identifier: Pair<Rule>,
         type_expr: Pair<Rule>,
         expr: Pair<Rule>,
@@ -86,8 +162,8 @@ impl PestParser {
         match (identifier.as_rule(), type_expr.as_rule(), expr.as_rule()) {
             (Rule::identifier, Rule::expr, Rule::expr) => Expression::Let(
                 identifier.as_str().to_string(),
-                Box::new(PestParser::build_ast_from_expr(type_expr)),
-                Box::new(PestParser::build_ast_from_expr(expr)),
+                Box::new(PestParser::build_ast_from_expr(self, type_expr)),
+                Box::new(PestParser::build_ast_from_expr(self, expr)),
             ),
             (_, _, _) => {
                 panic!(
@@ -101,6 +177,7 @@ impl PestParser {
     }
 
     fn build_lambda_expr(
+        &self,
         lambda_name: Pair<Rule>,
         param_list: Pair<Rule>,
         type_expr: Pair<Rule>,
@@ -120,11 +197,12 @@ impl PestParser {
                 ParamList {
                     params: param_list
                         .into_inner()
-                        .map(PestParser::build_param)
+                        .map(|it| self.build_param(it))
                         .collect(),
                 },
-                Box::new(PestParser::build_ast_from_expr(type_expr)),
-                Box::new(PestParser::build_ast_from_expr(body_expr)),
+                Box::new(PestParser::build_ast_from_expr(self, type_expr)),
+                Box::new(PestParser::build_ast_from_expr(self, body_expr)),
+                None,
             ),
             (_, _, _, _) => {
                 panic!(
@@ -138,110 +216,149 @@ impl PestParser {
         }
     }
 
-    fn build_param(pair: Pair<Rule>) -> Param {
+    fn build_param(&self, pair: Pair<Rule>) -> Param {
         match pair.as_rule() {
             Rule::param => {
                 let mut inner = pair.into_inner();
 
                 Param {
                     name: inner.next().unwrap().as_str().to_string(),
-                    type_expr: PestParser::build_ast_from_expr(inner.next().unwrap()),
+                    type_expr: PestParser::build_ast_from_expr(self, inner.next().unwrap()),
                 }
             }
             _ => panic!("Invalid parameter {:?}", pair.as_str()),
         }
     }
 
-    fn build_application_expr(identifier: Pair<Rule>, call: Pair<Rule>) -> Expression {
+    fn build_application_expr(&self, identifier: Pair<Rule>, call: Pair<Rule>) -> Expression {
         match (identifier.as_rule(), call.as_rule()) {
             (Rule::named, Rule::call) => Expression::Application(
                 Box::new(Expression::Named(identifier.as_str().to_string())),
                 ArgList {
-                    args: PestParser::build_arg_list(call),
+                    args: PestParser::build_arg_list(self, call),
                 },
             ),
             (_, _) => panic!("Invalid application {:?}({:?})", identifier, call),
         }
     }
 
-    fn build_arg_list(call: Pair<Rule>) -> Vec<Expression> {
+    fn build_arg_list(&self, call: Pair<Rule>) -> Vec<Expression> {
         let args_opt = call.into_inner().next();
 
         match args_opt {
             None => vec![],
-            Some(args) => args.into_inner().map(PestParser::build_arg).collect(),
+            Some(args) => args.into_inner().map(|it| self.build_arg(it)).collect(),
         }
     }
 
-    fn build_arg(pair: Pair<Rule>) -> Expression {
+    fn build_arg(&self, pair: Pair<Rule>) -> Expression {
         match pair.as_rule() {
-            Rule::arg => PestParser::build_ast_from_expr(pair.into_inner().next().unwrap()),
+            Rule::arg => PestParser::build_ast_from_expr(&self, pair.into_inner().next().unwrap()),
             _ => panic!("Invalid argument {:?}", pair.as_str()),
         }
     }
-}
 
-pub fn parse(input: &str) -> Result<Vec<Expression>, Error<Rule>> {
-    let mut ast = vec![];
+    pub fn parse_expr(&self, input: &str) -> Result<Vec<Expression>, Error<Rule>> {
+        let mut ast = vec![];
 
-    let pairs = PestParser::parse(Rule::expr, input)?;
+        let pairs = PestParser::parse(Rule::expr, input)?;
 
-    for pair in pairs {
-        ast.push(PestParser::build_ast_from_expr(pair));
+        for pair in pairs {
+            ast.push(PestParser::build_ast_from_expr(self, pair));
+        }
+
+        Ok(ast)
     }
 
-    Ok(ast)
+    pub fn new() -> Self {
+        Self {
+            operator_metadata_mapping: HashMap::new(),
+        }
+    }
+
+    pub fn new_with_operator_metadata(
+        operator_metadata_map: HashMap<&'a str, OperatorMetadata>,
+    ) -> PestParser<'a> {
+        Self {
+            operator_metadata_mapping: operator_metadata_map,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{ArgList, Expression, Param, ParamList};
-    use crate::pest_parser::{parse, PestParser};
+    use crate::ast::{
+        AffixPosition, ArgList, Associativity, Expression, OperatorMetadata, Param, ParamList,
+    };
+    use crate::pest_parser::PestParser;
+    use std::collections::HashMap;
 
     #[test]
     fn test_integer_literal() {
-        assert_eq!(parse("42"), Ok(vec![Expression::IntegerLiteral(42)]));
+        let parser = PestParser::new();
+
+        assert_eq!(
+            parser.parse_expr("42"),
+            Ok(vec![Expression::IntegerLiteral(42)])
+        );
     }
 
     #[test]
     fn test_string_literal() {
+        let parser = PestParser::new();
+
         assert_eq!(
-            parse("\"42\""),
+            parser.parse_expr("\"42\""),
             Ok(vec![Expression::StringLiteral("42".to_string())])
         );
     }
 
     #[test]
     fn test_boolean_literal() {
-        assert_eq!(parse("true"), Ok(vec![Expression::BooleanLiteral(true)]));
+        let parser = PestParser::new();
+
+        assert_eq!(
+            parser.parse_expr("true"),
+            Ok(vec![Expression::BooleanLiteral(true)])
+        );
     }
 
     #[test]
     fn test_named_expression() {
+        let parser = PestParser::new();
+
         assert_eq!(
-            parse("hello"),
+            parser.parse_expr("hello"),
             Ok(vec![Expression::Named("hello".to_string())])
         );
 
-        assert_eq!(parse("*"), Ok(vec![Expression::Named("*".to_string())]));
-
-        assert_eq!(parse("int"), Ok(vec![Expression::Named("int".to_string())]));
+        assert_eq!(
+            parser.parse_expr("*"),
+            Ok(vec![Expression::Named("*".to_string())])
+        );
 
         assert_eq!(
-            parse("bool"),
+            parser.parse_expr("int"),
+            Ok(vec![Expression::Named("int".to_string())])
+        );
+
+        assert_eq!(
+            parser.parse_expr("bool"),
             Ok(vec![Expression::Named("bool".to_string())])
         );
 
         assert_eq!(
-            parse("string"),
+            parser.parse_expr("string"),
             Ok(vec![Expression::Named("string".to_string())])
         )
     }
 
     #[test]
     fn test_let_expression() {
+        let parser = PestParser::new();
+
         assert_eq!(
-            parse("let three: 3 = 3"),
+            parser.parse_expr("let three: 3 = 3"),
             Ok(vec![Expression::Let(
                 "three".to_string(),
                 Box::new(Expression::IntegerLiteral(3)),
@@ -252,8 +369,10 @@ mod tests {
 
     #[test]
     fn test_lambda_expression() {
+        let parser = PestParser::new();
+
         assert_eq!(
-            parse("fn id(x: X) -> X { x } "),
+            parser.parse_expr("fn id(x: X) -> X { x } "),
             Ok(vec![Expression::Lambda(
                 Some("id".to_string()),
                 ParamList {
@@ -263,12 +382,13 @@ mod tests {
                     }]
                 },
                 Box::new(Expression::Named("X".to_string())),
-                Box::new(Expression::Named("x".to_string()))
+                Box::new(Expression::Named("x".to_string())),
+                None
             )])
         );
 
         assert_eq!(
-            parse("fn (x: X) -> X { x } "),
+            parser.parse_expr("fn (x: X) -> X { x } "),
             Ok(vec![Expression::Lambda(
                 None,
                 ParamList {
@@ -278,12 +398,13 @@ mod tests {
                     }]
                 },
                 Box::new(Expression::Named("X".to_string())),
-                Box::new(Expression::Named("x".to_string()))
+                Box::new(Expression::Named("x".to_string())),
+                None
             )])
         );
 
         assert_eq!(
-            parse("fn combine(x: X, y: Y) -> Z { x } "),
+            parser.parse_expr("fn combine(x: X, y: Y) -> Z { x } "),
             Ok(vec![Expression::Lambda(
                 Some("combine".to_string()),
                 ParamList {
@@ -299,12 +420,13 @@ mod tests {
                     ]
                 },
                 Box::new(Expression::Named("Z".to_string())),
-                Box::new(Expression::Named("x".to_string()))
+                Box::new(Expression::Named("x".to_string())),
+                None
             )])
         );
 
         assert_eq!(
-            parse("fn Id(X: *) -> * { X } "),
+            parser.parse_expr("fn Id(X: *) -> * { X } "),
             Ok(vec![Expression::Lambda(
                 Some("Id".to_string()),
                 ParamList {
@@ -314,12 +436,13 @@ mod tests {
                     }]
                 },
                 Box::new(Expression::Named("*".to_string())),
-                Box::new(Expression::Named("X".to_string()))
+                Box::new(Expression::Named("X".to_string())),
+                None
             )])
         );
 
         assert_eq!(
-            parse("fn addTwo(x: int) -> int { x + 2 } "),
+            parser.parse_expr("fn addTwo(x: int) -> int { x + 2 } "),
             Ok(vec![Expression::Lambda(
                 Some("addTwo".to_string()),
                 ParamList {
@@ -329,19 +452,22 @@ mod tests {
                     }]
                 },
                 Box::new(Expression::Named("int".to_string())),
-                Box::new(Expression::InfixOperation(
-                    "+".to_string(),
-                    Box::new(Expression::Named("x".to_string())),
-                    Box::new(Expression::IntegerLiteral(2))
-                ))
+                Box::new(Expression::infix_operation(
+                    Expression::Named("+".to_string()),
+                    Expression::Named("x".to_string()),
+                    Expression::IntegerLiteral(2)
+                )),
+                None
             )])
         )
     }
 
     #[test]
     fn test_application_expression() {
+        let parser = PestParser::new();
+
         assert_eq!(
-            parse("x()"),
+            parser.parse_expr("x()"),
             Ok(vec![Expression::Application(
                 Box::new(Expression::Named("x".to_string())),
                 ArgList { args: vec![] }
@@ -349,7 +475,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse("x(3)"),
+            parser.parse_expr("x(3)"),
             Ok(vec![Expression::Application(
                 Box::new(Expression::Named("x".to_string())),
                 ArgList {
@@ -359,7 +485,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse("x(a)"),
+            parser.parse_expr("x(a)"),
             Ok(vec![Expression::Application(
                 Box::new(Expression::Named("x".to_string())),
                 ArgList {
@@ -369,7 +495,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse("x(a, b)"),
+            parser.parse_expr("x(a, b)"),
             Ok(vec![Expression::Application(
                 Box::new(Expression::Named("x".to_string())),
                 ArgList {
@@ -382,7 +508,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse("x(3, 4)"),
+            parser.parse_expr("x(3, 4)"),
             Ok(vec![Expression::Application(
                 Box::new(Expression::Named("x".to_string())),
                 ArgList {
@@ -394,31 +520,93 @@ mod tests {
 
     #[test]
     fn test_infix_expression() {
+        let parser = PestParser::new_with_operator_metadata(HashMap::from_iter([(
+            "^",
+            OperatorMetadata {
+                position: AffixPosition::In,
+                associativity: Associativity::Right,
+                precedence: 30,
+            },
+        )]));
+
         assert_eq!(
-            parse("a+b"),
-            Ok(vec![Expression::InfixOperation(
-                "+".to_string(),
-                Box::new(Expression::Named("a".to_string())),
-                Box::new(Expression::Named("b".to_string()))
+            parser.parse_expr("a+b"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("+".to_string()),
+                Expression::Named("a".to_string()),
+                Expression::Named("b".to_string())
             )])
         );
 
         assert_eq!(
-            parse("a + b"),
-            Ok(vec![Expression::InfixOperation(
-                "+".to_string(),
-                Box::new(Expression::Named("a".to_string())),
-                Box::new(Expression::Named("b".to_string()))
+            parser.parse_expr("a + b"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("+".to_string()),
+                Expression::Named("a".to_string()),
+                Expression::Named("b".to_string())
             )])
         );
 
         assert_eq!(
-            parse("a add b"),
-            Ok(vec![Expression::InfixOperation(
-                "add".to_string(),
-                Box::new(Expression::Named("a".to_string())),
-                Box::new(Expression::Named("b".to_string()))
+            parser.parse_expr("a ^ b ^ c"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("^".to_string()),
+                Expression::Named("a".to_string()),
+                Expression::infix_operation(
+                    Expression::Named("^".to_string()),
+                    Expression::Named("b".to_string()),
+                    Expression::Named("c".to_string())
+                )
             )])
-        )
+        );
+
+        assert_eq!(
+            parser.parse_expr("a + b + c"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("+".to_string()),
+                Expression::infix_operation(
+                    Expression::Named("+".to_string()),
+                    Expression::Named("a".to_string()),
+                    Expression::Named("b".to_string())
+                ),
+                Expression::Named("c".to_string()),
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("a * b + c"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("+".to_string()),
+                Expression::infix_operation(
+                    Expression::Named("*".to_string()),
+                    Expression::Named("a".to_string()),
+                    Expression::Named("b".to_string())
+                ),
+                Expression::Named("c".to_string())
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("a add b"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Named("add".to_string()),
+                Expression::Named("a".to_string()),
+                Expression::Named("b".to_string())
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("a add(int) b"),
+            Ok(vec![Expression::infix_operation(
+                Expression::Application(
+                    Box::new(Expression::Named("add".to_string())),
+                    ArgList {
+                        args: vec![Expression::Named("int".to_string())]
+                    }
+                ),
+                Expression::Named("a".to_string()),
+                Expression::Named("b".to_string())
+            )])
+        );
     }
 }

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -673,5 +673,58 @@ mod tests {
                 Expression::Named("b".to_string())
             )])
         );
+
+        assert_eq!(
+            parser.parse_expr("x(3 + 2 + 5, 4 + 4 * 5 - 5)"),
+            Ok(vec![Expression::Application(
+                Box::new(Expression::Named("x".to_string())),
+                ArgList {
+                    args: vec![
+                        Expression::Application(
+                            Box::new(Expression::Named("+".to_string())),
+                            ArgList {
+                                args: vec![
+                                    Expression::Application(
+                                        Box::new(Expression::Named("+".to_string())),
+                                        ArgList {
+                                            args: vec![
+                                                Expression::IntegerLiteral(3),
+                                                Expression::IntegerLiteral(2)
+                                            ]
+                                        }
+                                    ),
+                                    Expression::IntegerLiteral(5)
+                                ]
+                            }
+                        ),
+                        Expression::Application(
+                            Box::new(Expression::Named("-".to_string())),
+                            ArgList {
+                                args: vec![
+                                    Expression::Application(
+                                        Box::new(Expression::Named("+".to_string())),
+                                        ArgList {
+                                            args: vec![
+                                                Expression::IntegerLiteral(4),
+                                                Expression::Application(
+                                                    Box::new(Expression::Named("*".to_string())),
+                                                    ArgList {
+                                                        args: vec![
+                                                            Expression::IntegerLiteral(4),
+                                                            Expression::IntegerLiteral(5)
+                                                        ]
+                                                    }
+                                                )
+                                            ]
+                                        }
+                                    ),
+                                    Expression::IntegerLiteral(5)
+                                ]
+                            }
+                        )
+                    ]
+                }
+            )])
+        )
     }
 }


### PR DESCRIPTION
This took me a while to get right with how iteration with `pest.rs` pairs works (ie. `into_inner` consumes a pair, etc). 
I took the opportunity to unify infix expressions and applications into just application nodes for easier handling. This should make it easier to use normal functions in infix positions. More care might be needed in handling this, however.

The plan is to eventually support custom user-defined precedence.

Closes #7 