### PR TITLE
Restrict parametric polymorphism

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -55,9 +55,47 @@ pub enum Associativity {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
+pub struct TypeParam {
+    pub name: String,
+    pub type_expr: Option<Expression>,
+}
+
+impl TypeParam {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            type_expr: None,
+        }
+    }
+
+    pub fn new_typed(name: String, type_expr: Expression) -> Self {
+        Self {
+            name,
+            type_expr: Some(type_expr),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Param {
     pub name: String,
-    pub type_expr: Expression,
+    pub type_expr: Option<Expression>,
+}
+
+impl Param {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            type_expr: None,
+        }
+    }
+
+    pub fn new_typed(name: String, type_expr: Expression) -> Self {
+        Self {
+            name,
+            type_expr: Some(type_expr),
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -67,7 +105,51 @@ pub struct ArgList {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ParamList {
+    pub type_params: Vec<TypeParam>,
     pub params: Vec<Param>,
+}
+
+impl ParamList {
+    pub fn new() -> Self {
+        Self {
+            type_params: vec![],
+            params: vec![],
+        }
+    }
+
+    pub fn add_type_param(self, type_param: TypeParam) -> Self {
+        let mut type_params = self.type_params.clone();
+        type_params.push(type_param);
+
+        Self {
+            type_params,
+            params: self.params.clone(),
+        }
+    }
+
+    pub fn add_param(self, param: Param) -> Self {
+        let mut params = self.params.clone();
+        params.push(param);
+
+        Self {
+            type_params: self.type_params.clone(),
+            params,
+        }
+    }
+
+    pub fn set_params(self, params: Vec<Param>) -> Self {
+        Self {
+            type_params: self.type_params.clone(),
+            params,
+        }
+    }
+
+    pub fn set_type_params(self, type_params: Vec<TypeParam>) -> Self {
+        Self {
+            type_params,
+            params: self.params.clone(),
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/ast_helpers.rs
+++ b/src/ast_helpers.rs
@@ -36,12 +36,9 @@ macro_rules! let_expr {
 }
 
 #[macro_export]
-macro_rules! p {
+macro_rules! typed_param {
     ($name:literal : $tpe:expr) => {
-        Param {
-            name: $name.to_string(),
-            type_expr: $tpe,
-        }
+        Param::new_typed($name.to_string(), $tpe)
     };
 }
 
@@ -49,13 +46,14 @@ macro_rules! p {
 macro_rules! lambda {
     ($($name:literal,)? {$( $param:expr );*} -> $tpe:expr , body: $body:expr $(,$op_metadata:expr,)?) => {
         {
+            let mut type_params = Vec::new();
             let mut params = Vec::new();
             let mut name = None;
             let mut op_metadata = None;
             $( params.push($param); )*
             $( name = Some($name.to_string()); )?
             $( op_metadata = Some($op_metadata); )?
-            Expression::Lambda(name, ParamList { params }, Box::new($tpe), Box::new($body), op_metadata)
+            Expression::Lambda(name, ParamList { type_params, params }, Box::new($tpe), Box::new($body), op_metadata)
         }
     };
 }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -33,11 +33,16 @@ RPAREN = _{ ")" }
 
 fn_tag = _{ "fn" }
 
-param = { identifier ~ TYPESIG_COLON ~ expr }
-param_list = { param ~ (COMMA_SEP ~ param)* }
+param = { identifier ~ (TYPESIG_COLON ~ expr)? }
+params = { LPAREN ~ (param ~ (COMMA_SEP ~ param)*)? ~ RPAREN }
+
+LANGLE = _{ "<" }
+RANGLE = _{ ">" }
+type_param = { identifier ~ (TYPESIG_COLON ~ expr)? }
+type_params = { (LANGLE ~ type_param ~ (COMMA_SEP ~ type_param)* ~ RANGLE)? }
 
 lambda_name = { identifier? }
-lambda_expr = { fn_tag ~ lambda_name ~ LPAREN ~ param_list? ~ RPAREN ~ LAMBDA_ARROW  ~ expr ~ LBRACE ~ expr ~ RBRACE }
+lambda_expr = { fn_tag ~ lambda_name ~ type_params ~ params ~ LAMBDA_ARROW  ~ expr ~ LBRACE ~ expr ~ RBRACE }
 
 arg = { expr }
 arg_list = { arg ~ (COMMA_SEP ~ arg)* }

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -464,6 +464,17 @@ mod tests {
         );
 
         assert_eq!(
+            parser.parse_expr("fn (x) -> Int { x } "),
+            Ok(vec![Expression::Lambda(
+                None,
+                ParamList::new().add_param(Param::new("x".to_string())),
+                Box::new(Expression::Named("Int".to_string())),
+                Box::new(Expression::Named("x".to_string())),
+                None
+            )])
+        );
+
+        assert_eq!(
             parser.parse_expr("fn combine(x: X, y: Y) -> Z { x } "),
             Ok(vec![Expression::Lambda(
                 Some("combine".to_string()),

--- a/src/pest_parser.rs
+++ b/src/pest_parser.rs
@@ -1,5 +1,6 @@
 use crate::ast::{
     AffixPosition, ArgList, Associativity, Expression, OperatorMetadata, Param, ParamList,
+    TypeParam,
 };
 use pest::error::Error;
 use pest::iterators::{Pair, Pairs};
@@ -117,11 +118,19 @@ impl<'a> PestParser<'a> {
                 let pairs = &mut pair.into_inner();
 
                 let lambda_name = pairs.next().unwrap();
-                let param_list = pairs.next().unwrap();
+                let type_params = pairs.next();
+                let params = pairs.next().unwrap();
                 let type_expr = pairs.next().unwrap();
                 let body_expr = pairs.next().unwrap();
 
-                PestParser::build_lambda_expr(self, lambda_name, param_list, type_expr, body_expr)
+                PestParser::build_lambda_expr(
+                    self,
+                    lambda_name,
+                    type_params,
+                    params,
+                    type_expr,
+                    body_expr,
+                )
             }
             Rule::invocation => {
                 let pairs = &mut pair.into_inner();
@@ -182,27 +191,25 @@ impl<'a> PestParser<'a> {
     fn build_lambda_expr(
         &self,
         lambda_name: Pair<Rule>,
-        param_list: Pair<Rule>,
+        type_params: Option<Pair<Rule>>,
+        params: Pair<Rule>,
         type_expr: Pair<Rule>,
         body_expr: Pair<Rule>,
     ) -> Expression {
         match (
             lambda_name.as_rule(),
-            param_list.as_rule(),
+            params.as_rule(),
             type_expr.as_rule(),
             body_expr.as_rule(),
         ) {
-            (Rule::lambda_name, Rule::param_list, Rule::expr, Rule::expr) => Expression::Lambda(
+            (Rule::lambda_name, Rule::params, Rule::expr, Rule::expr) => Expression::Lambda(
                 lambda_name
                     .into_inner()
                     .next()
                     .map(|identifier| identifier.as_str().to_string()),
-                ParamList {
-                    params: param_list
-                        .into_inner()
-                        .map(|it| self.build_param(it))
-                        .collect(),
-                },
+                ParamList::new()
+                    .set_params(params.into_inner().map(|it| self.build_param(it)).collect())
+                    .set_type_params(self.build_type_params(type_params)),
                 Box::new(PestParser::build_ast_from_expr(self, type_expr)),
                 Box::new(PestParser::build_ast_from_expr(self, body_expr)),
                 None,
@@ -211,7 +218,7 @@ impl<'a> PestParser<'a> {
                 panic!(
                     "Invalid lambda expr {:?}({:?}) -> {:?} = {:?}",
                     lambda_name.as_str(),
-                    param_list.as_str(),
+                    params.as_str(),
                     type_expr.as_str(),
                     body_expr.as_str()
                 )
@@ -219,14 +226,47 @@ impl<'a> PestParser<'a> {
         }
     }
 
+    fn build_type_params(&self, type_params_opt: Option<Pair<Rule>>) -> Vec<TypeParam> {
+        match type_params_opt.map(|pair| (pair.clone(), pair.clone().as_rule())) {
+            None => Vec::new(),
+            Some((pair, Rule::type_params)) => pair
+                .into_inner()
+                .map(|it| self.build_type_param(it))
+                .collect(),
+            Some((pair, _)) => panic!("Invalid type params {:?}", pair),
+        }
+    }
+
+    fn build_type_param(&self, pair: Pair<Rule>) -> TypeParam {
+        match pair.as_rule() {
+            Rule::type_param => {
+                let mut inner = pair.into_inner();
+                let name = inner.next().unwrap().as_str().to_string();
+
+                match inner.next() {
+                    None => TypeParam::new(name),
+                    Some(pair) => {
+                        let type_expr = PestParser::build_ast_from_expr(self, pair);
+                        TypeParam::new_typed(name, type_expr)
+                    }
+                }
+            }
+            _ => panic!("Invalid type param {:?}", pair.as_str()),
+        }
+    }
+
     fn build_param(&self, pair: Pair<Rule>) -> Param {
         match pair.as_rule() {
             Rule::param => {
                 let mut inner = pair.into_inner();
+                let name = inner.next().unwrap().as_str().to_string();
 
-                Param {
-                    name: inner.next().unwrap().as_str().to_string(),
-                    type_expr: PestParser::build_ast_from_expr(self, inner.next().unwrap()),
+                match inner.next() {
+                    None => Param::new(name),
+                    Some(pair) => {
+                        let type_expr = PestParser::build_ast_from_expr(self, pair);
+                        Param::new_typed(name, type_expr)
+                    }
                 }
             }
             _ => panic!("Invalid parameter {:?}", pair.as_str()),
@@ -292,6 +332,7 @@ impl<'a> PestParser<'a> {
 mod tests {
     use crate::ast::{
         AffixPosition, ArgList, Associativity, Expression, OperatorMetadata, Param, ParamList,
+        TypeParam,
     };
     use crate::pest_parser::PestParser;
     use std::collections::HashMap;
@@ -375,15 +416,34 @@ mod tests {
         let parser = PestParser::new();
 
         assert_eq!(
-            parser.parse_expr("fn id(x: X) -> X { x } "),
+            parser.parse_expr("fn id<X>(x: X) -> X { x } "),
             Ok(vec![Expression::Lambda(
                 Some("id".to_string()),
-                ParamList {
-                    params: vec![Param {
-                        name: "x".to_string(),
-                        type_expr: Expression::Named("X".to_string())
-                    }]
-                },
+                ParamList::new()
+                    .add_type_param(TypeParam::new("X".to_string()))
+                    .add_param(Param::new_typed(
+                        "x".to_string(),
+                        Expression::Named("X".to_string())
+                    )),
+                Box::new(Expression::Named("X".to_string())),
+                Box::new(Expression::Named("x".to_string())),
+                None
+            )])
+        );
+
+        assert_eq!(
+            parser.parse_expr("fn id<X: Numeric>(x: X) -> X { x } "),
+            Ok(vec![Expression::Lambda(
+                Some("id".to_string()),
+                ParamList::new()
+                    .add_type_param(TypeParam::new_typed(
+                        "X".to_string(),
+                        Expression::Named("Numeric".to_string())
+                    ))
+                    .add_param(Param::new_typed(
+                        "x".to_string(),
+                        Expression::Named("X".to_string())
+                    )),
                 Box::new(Expression::Named("X".to_string())),
                 Box::new(Expression::Named("x".to_string())),
                 None
@@ -394,12 +454,9 @@ mod tests {
             parser.parse_expr("fn (x: X) -> X { x } "),
             Ok(vec![Expression::Lambda(
                 None,
-                ParamList {
-                    params: vec![Param {
-                        name: "x".to_string(),
-                        type_expr: Expression::Named("X".to_string())
-                    }]
-                },
+                ParamList::new().add_param(
+                    Param::new_typed("x".to_string(), Expression::Named("X".to_string()))
+                ),
                 Box::new(Expression::Named("X".to_string())),
                 Box::new(Expression::Named("x".to_string())),
                 None
@@ -410,18 +467,15 @@ mod tests {
             parser.parse_expr("fn combine(x: X, y: Y) -> Z { x } "),
             Ok(vec![Expression::Lambda(
                 Some("combine".to_string()),
-                ParamList {
-                    params: vec![
-                        Param {
-                            name: "x".to_string(),
-                            type_expr: Expression::Named("X".to_string())
-                        },
-                        Param {
-                            name: "y".to_string(),
-                            type_expr: Expression::Named("Y".to_string())
-                        }
-                    ]
-                },
+                ParamList::new()
+                    .add_param(Param::new_typed(
+                        "x".to_string(),
+                        Expression::Named("X".to_string())
+                    ))
+                    .add_param(Param::new_typed(
+                        "y".to_string(),
+                        Expression::Named("Y".to_string())
+                    )),
                 Box::new(Expression::Named("Z".to_string())),
                 Box::new(Expression::Named("x".to_string())),
                 None
@@ -432,12 +486,9 @@ mod tests {
             parser.parse_expr("fn Id(X: *) -> * { X } "),
             Ok(vec![Expression::Lambda(
                 Some("Id".to_string()),
-                ParamList {
-                    params: vec![Param {
-                        name: "X".to_string(),
-                        type_expr: Expression::Named("*".to_string())
-                    }]
-                },
+                ParamList::new().add_param(
+                    Param::new_typed("X".to_string(), Expression::Named("*".to_string()))
+                ),
                 Box::new(Expression::Named("*".to_string())),
                 Box::new(Expression::Named("X".to_string())),
                 None
@@ -448,12 +499,10 @@ mod tests {
             parser.parse_expr("fn addTwo(x: int) -> int { x + 2 } "),
             Ok(vec![Expression::Lambda(
                 Some("addTwo".to_string()),
-                ParamList {
-                    params: vec![Param {
-                        name: "x".to_string(),
-                        type_expr: Expression::Named("int".to_string())
-                    }]
-                },
+                ParamList::new().add_param(Param::new_typed(
+                    "x".to_string(),
+                    Expression::Named("int".to_string())
+                )),
                 Box::new(Expression::Named("int".to_string())),
                 Box::new(Expression::infix_operation(
                     Expression::Named("+".to_string()),

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -19,6 +19,19 @@ impl Substitution {
         }
     }
 
+    pub fn filter_type_vars(&self, type_vars: Vec<String>) -> Self {
+        let new_type_var_map: HashMap<String, Type> = self
+            .type_var_map
+            .clone()
+            .into_iter()
+            .filter(|(k, _)| type_vars.contains(k))
+            .collect();
+
+        Substitution {
+            type_var_map: new_type_var_map,
+        }
+    }
+
     pub fn compose(&self, other: &Substitution) -> Self {
         let new_type_var_map: HashMap<String, Type> = other
             .type_var_map

--- a/src/type_environment.rs
+++ b/src/type_environment.rs
@@ -2,7 +2,7 @@ use crate::r#type::{Type, TypeScheme};
 use crate::substitution::{Substitutable, Substitution};
 use std::collections::HashMap;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct TypeEnvironment {
     pub bindings: HashMap<String, TypeScheme>,
     pub aliases: HashMap<String, Type>,

--- a/src/typer.rs
+++ b/src/typer.rs
@@ -73,12 +73,8 @@ impl<'a> Typer<'a> {
                 _,
             ) => {
                 let (res, param_types) = Typer::collect_param_env(self, type_params, params, env);
-                println!("param_types: {:?}", param_types);
                 let new_env = res?;
-                println!("new_env: {:?}", new_env.clone());
                 let (return_type, substitution) = Typer::ti(self, *body, new_env)?.as_tuple();
-
-                println!("substitution: {:?}", substitution);
 
                 Ok(Inference::Partial(
                     param_types.iter().fold(return_type, |acc, tpe| {


### PR DESCRIPTION
This PR adds generics (type parameters) and restricts parametric polymorphism. Thus,

```rust
fn identity(x: a) -> a { x }
```
is now invalid and should be written as

```rust
fn identity<x>(x: a) -> a { x }
```