### PR TITLE
Allow return types to be optional

### DIFF
--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -8,7 +8,7 @@ pub enum Expression {
     Lambda(
         Option<String>,
         ParamList,
-        Box<Expression>,
+        Option<Box<Expression>>,
         Box<Expression>,
         Option<OperatorMetadata>,
     ),

--- a/src/syntax/ast_helpers.rs
+++ b/src/syntax/ast_helpers.rs
@@ -64,19 +64,21 @@ macro_rules! type_param {
 pub(crate) use type_param;
 
 macro_rules! lambda {
-    ($($name:literal)?, $(types: $($type_param:expr);+,)? {$( $param:expr );*} -> $tpe:expr , body: $body:expr $(,$op_metadata:expr,)?) => {
+    ($($name:literal)?, $(types: $($type_param:expr);+,)? {$( $param:expr );*} -> $($return_tpe:expr)? , body: $body:expr $(,$op_metadata:expr,)?) => {
         {
             let mut type_params = Vec::new();
             let mut params = Vec::new();
             let mut name = None;
             let mut op_metadata = None;
+            let mut return_tpe = None;
             $( params.push($param); )*
             $( name = Some($name.to_string()); )?
             $( op_metadata = Some($op_metadata); )?
             $( $(
                 type_params.push($type_param);
             )+ )?
-            Expression::Lambda(name, ParamList { type_params, params }, Box::new($tpe), Box::new($body), op_metadata)
+            $( return_tpe = Some(Box::new($return_tpe)); )?
+            Expression::Lambda(name, ParamList { type_params, params }, return_tpe, Box::new($body), op_metadata)
         }
     };
 }

--- a/src/syntax/grammar.pest
+++ b/src/syntax/grammar.pest
@@ -41,8 +41,9 @@ RANGLE = _{ ">" }
 type_param = { identifier ~ (TYPESIG_COLON ~ expr)? }
 type_params = { (LANGLE ~ type_param ~ (COMMA_SEP ~ type_param)* ~ RANGLE)? }
 
+return_type_expr = { expr? }
 lambda_name = { identifier? }
-lambda_expr = { fn_tag ~ lambda_name ~ type_params ~ params ~ LAMBDA_ARROW  ~ expr ~ LBRACE ~ expr ~ RBRACE }
+lambda_expr = { fn_tag ~ lambda_name ~ type_params ~ params ~ LAMBDA_ARROW ~ return_type_expr ~ LBRACE ~ expr ~ RBRACE }
 
 arg = { expr }
 arg_list = { arg ~ (COMMA_SEP ~ arg)* }

--- a/src/typesystem/typer.rs
+++ b/src/typesystem/typer.rs
@@ -142,6 +142,13 @@ impl Typer {
         }
     }
 
+    fn are_types_isomorphic(&self, tpe1: Type, tpe2: Type) -> bool {
+        match self.unify(tpe1.clone(), tpe2.clone()) {
+            Ok(ref subst) if tpe1.apply_substitution(subst) == tpe2 => true,
+            _ => false,
+        }
+    }
+
     #[inline]
     fn instantiate(&self, scheme: TypeScheme) -> Type {
         let new_vars = scheme
@@ -408,6 +415,23 @@ mod tests {
                 Box::new(Type::Primitive(PrimitiveType::Int))
             )
         )
+    }
+
+    #[test]
+    fn test_polymorphic_named_lambda_with_no_type_annotation() {
+        let typer = setup_typer_for_lambda_tests();
+        let env = TypeEnvironment::new();
+
+        assert!(typer.are_types_isomorphic(
+            typer.infer_and_panic(
+                lambda! { "identity", { param!("x") } -> , body: named!("x") },
+                env.clone()
+            ),
+            Type::Function(
+                Box::new(Type::TypeVar("a".to_string())),
+                Box::new(Type::TypeVar("a".to_string()))
+            ),
+        ))
     }
 
     #[test]


### PR DESCRIPTION
Return types are no longer required in the signature, one can write `fn (x) -> { ... }` and the return type will be inferred as well.